### PR TITLE
CVU-99 Add "backend_config" to MANIFEST.IN

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include cvu/detector/yolov5/backends/weights/*.json
+include cvu/utils/backend/*.json


### PR DESCRIPTION

Reason for PR
- pip install fails with new backend config introduced in `@CVU-74 Upgrade backend-setup`

New changes or Fix
- include `cvu/utils/backend/backend_config.json` to `MANIFEST.IN` for packaging purposes

Test
- manually tested pip installation from branch on Ubuntu & Colab